### PR TITLE
doc: [ssh] Use `%n` for `ProxyCommand` hostname

### DIFF
--- a/website/content/docs/common-workflows/workflow-ssh-proxycommand.mdx
+++ b/website/content/docs/common-workflows/workflow-ssh-proxycommand.mdx
@@ -19,7 +19,7 @@ Start by configuring a `Host` entry in `.ssh/ssh_config` for `localhost`:
 
 ```bash
 Host ttcp_*
-  ProxyCommand sh -c "boundary connect -target-id %h -exec nc -- {{boundary.ip}} {{boundary.port}}"
+  ProxyCommand sh -c "boundary connect -target-id %n -exec nc -- {{boundary.ip}} {{boundary.port}}"
 ```
 
 The `ProxyCommand` tells the SSH client to invoke `boundary connect`. We are passing the `-exec nc` flag to


### PR DESCRIPTION
This fixes an issue that occurs when the target ID contains any uppercase letters (e.g. `ttcp_xFAbYxv5m9`).

When using `%h`, the hostname is first lowercased before being substituted in, which causes the command to fail because the target doesn't exist.

Instead, use `%n`, which is the original remote hostname, as given on the command line.

Ref: https://man7.org/linux/man-pages/man5/ssh_config.5.html#TOKENS